### PR TITLE
feat: Convert presentation to a digital book

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,12 +27,16 @@
         
         /* Estilos para páginas */
         .page {
+            display: none; /* Ocultar todas las páginas por defecto */
             background-color: white;
             box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
             margin-bottom: 30px;
             padding: 40px;
             border-radius: 10px;
-            page-break-after: always;
+        }
+
+        .page.active {
+            display: block; /* Mostrar la página activa */
         }
         
         /* Estilos para encabezados */
@@ -242,6 +246,37 @@
             h2 {
                 font-size: 1.5rem;
             }
+        }
+
+        /* Estilos para los botones de navegación */
+        .navigation-buttons {
+            position: fixed;
+            bottom: 20px;
+            left: 50%;
+            transform: translateX(-50%);
+            display: flex;
+            gap: 20px;
+            z-index: 1000;
+        }
+
+        .nav-button {
+            padding: 10px 20px;
+            font-size: 1rem;
+            cursor: pointer;
+            background-color: #3498db;
+            color: white;
+            border: none;
+            border-radius: 5px;
+            transition: background-color 0.3s;
+        }
+
+        .nav-button:hover:not(:disabled) {
+            background-color: #2980b9;
+        }
+
+        .nav-button:disabled {
+            background-color: #bdc3c7;
+            cursor: not-allowed;
         }
     </style>
 </head>
@@ -466,5 +501,51 @@
             <p>Prohibida la reproducción total o parcial sin autorización</p>
         </div>
     </div>
+
+    <div class="navigation-buttons">
+        <button id="prev-button" class="nav-button" disabled>Anterior</button>
+        <button id="next-button" class="nav-button">Siguiente</button>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const pages = document.querySelectorAll('.page');
+            const prevButton = document.getElementById('prev-button');
+            const nextButton = document.getElementById('next-button');
+
+            let currentPageIndex = 0;
+
+            function showPage(index) {
+                // Hide all pages
+                pages.forEach((page, i) => {
+                    page.classList.toggle('active', i === index);
+                });
+
+                // Update button states
+                prevButton.disabled = index === 0;
+                nextButton.disabled = index === pages.length - 1;
+
+                // Scroll to the top of the page
+                window.scrollTo(0, 0);
+            }
+
+            prevButton.addEventListener('click', () => {
+                if (currentPageIndex > 0) {
+                    currentPageIndex--;
+                    showPage(currentPageIndex);
+                }
+            });
+
+            nextButton.addEventListener('click', () => {
+                if (currentPageIndex < pages.length - 1) {
+                    currentPageIndex++;
+                    showPage(currentPageIndex);
+                }
+            });
+
+            // Show the first page initially
+            showPage(currentPageIndex);
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
This commit transforms the static HTML presentation into an interactive digital book.

Key changes include:
- Added CSS to hide all pages by default and display only the active one.
- Implemented 'Next' and 'Previous' navigation buttons using HTML and CSS.
- Added JavaScript to handle the page navigation logic, including button state management and scrolling to the top of the page on navigation.
- The functionality was visually verified using Playwright to ensure correctness.